### PR TITLE
Django 2 form media compatibility.

### DIFF
--- a/bootstrap3_datetime/widgets.py
+++ b/bootstrap3_datetime/widgets.py
@@ -61,12 +61,8 @@ def get_momentjs_supported_locale():
 
 class DateTimePicker(DateTimeInput):
     class Media:
-        class JsFiles(object):
-            def __iter__(self):
-                yield 'bootstrap3_datetime/js/moment-with-locales.min.js'
-                yield 'bootstrap3_datetime/js/bootstrap-datetimepicker.min.js'
-
-        js = JsFiles()
+        js = ('bootstrap3_datetime/js/moment-with-locales.min.js',
+              'bootstrap3_datetime/js/bootstrap-datetimepicker.min.js')
         css = {'all': ('bootstrap3_datetime/css/bootstrap-datetimepicker.min.css',), }
 
     # http://momentjs.com/docs/#/parsing/string-format/


### PR DESCRIPTION
Django >=2 requires form media to be iterables, instead of generators.