### PR TITLE
Dynamically created controls

### DIFF
--- a/bootstrap3_datetime/widgets.py
+++ b/bootstrap3_datetime/widgets.py
@@ -93,11 +93,22 @@ class DateTimePicker(DateTimeInput):
                 var callback = function() {
                     $(function(){$("#%(picker_id)s:has(input:not([readonly],[disabled]))").datetimepicker(%(options)s);});
                 };
-                if(window.addEventListener)
+                // if window object id loaded already, call directly callback function
+                if (-1 != $.inArray(
+                        document.readyState,
+                        ["loaded", "interactive", "complete"]
+                    )
+                ) {
+                    callback();
+                } 
+                else if (window.addEventListener) {
                     window.addEventListener("load", callback, false);
-                else if (window.attachEvent)
+                }
+                else if (window.attachEvent) {
                     window.attachEvent("onload", callback);
-                else window.onload = callback;
+                }
+                else
+                    window.onload = callback;
             })(window);
         </script>'''
 


### PR DESCRIPTION
Merged https://github.com/nkunihiko/django-bootstrap3-datetimepicker/pull/52, so that `DatetimePicker` can be activated when the form is dynamically injected into the DOM. This is useful for AJAX form with `DatetimePicker` widget when the form has to be created dynamcially.